### PR TITLE
feat: Change output format to CSV

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,20 +32,17 @@ def main():
         ])
 
         # Define I/O paths
-        input_path = "data/raw"
-        output_path_parquet = "data/processed/parquet"
-        output_path_delta = "data/processed/delta"
+        import os
+        input_path = "file:///" + os.path.abspath("data/raw")
+        output_path_csv = "file:///" + os.path.abspath("data/processed/output.csv")
 
         # Run ETL pipeline
         raw_df = read_data(spark, input_path, schema)
         if raw_df:
             transformed_df = transform_data(raw_df)
 
-            # Write to Parquet
-            write_data(transformed_df, output_path_parquet, "parquet")
-
-            # Write to Delta
-            write_data(transformed_df, output_path_delta, "delta")
+            # Write to a single CSV file
+            write_data(transformed_df, output_path_csv)
 
             logging.info("ETL pipeline finished successfully.")
         else:

--- a/tests/test_etl.py
+++ b/tests/test_etl.py
@@ -62,15 +62,15 @@ class TestEtl(unittest.TestCase):
         data = [(1, "a"), (2, "b")]
         df = self.spark.createDataFrame(data, schema)
 
-        # Write the DataFrame to a Parquet file in a dedicated subdirectory
+        # Write the DataFrame to a CSV file in a dedicated subdirectory
         output_path = os.path.join(self.temp_dir, "read_write_test")
 
-        write_data(df, output_path, "parquet")
+        write_data(df, output_path)
 
         # Read the data back
-        # Since we are writing parquet, the input path for reading should be the same.
-        # Spark will read the parquet files from the directory.
-        read_df = self.spark.read.parquet(output_path)
+        # Since we are writing a CSV, we need to read it back as a CSV.
+        # Spark writes the CSV to a directory with a part file, so we need to read the directory.
+        read_df = self.spark.read.csv(output_path, header=True, inferSchema=True)
 
         # Assertions
         self.assertEqual(df.count(), read_df.count())


### PR DESCRIPTION
This commit changes the output format of the ETL pipeline from Parquet and Delta to a single CSV file. The `write_data` function has been updated to write a single CSV file, and the main application has been updated to call the new function. The tests have also been updated to reflect this change.